### PR TITLE
Making it possible to have the parcel file in any sub-directory instead of only the project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Lektor website that use this plugin.
 
 ## Manual Builds
 
-To manually trigger a build that also invokes webpack you can use `lektor build -f npm`.
+To manually trigger a build that also invokes npm you can use `lektor build -f npm`.
 
 ## Including The Files
 

--- a/lektor_npm_support.py
+++ b/lektor_npm_support.py
@@ -114,8 +114,10 @@ class NPMSupportPlugin(Plugin):
         config = self.get_config()
         for section in config.itersections():
             props = config.section_as_dict(section)
+            section_folders = section.split('.')
+            folder = os.path.join(self.env.root_path, *section_folders)
             yield NPMRunner(
-                folder=os.path.join(self.env.root_path, section),
+                folder=folder,
                 npm=props.get('npm', 'npm'),
                 build_script=props.get('build_script', 'build'),
                 watch_script=props.get('watch_script', 'watch')


### PR DESCRIPTION
* Making it possible to have the parcel file in any sub-directory  by separating the path with dots in the section name like this : [themes.microcaps.parcel]

* Removing a leftover reference to webpack in Readme

The intend was to work on a theme with the build logic inside the theme itself.
I ran into another or maybe subtly related issue with parcel ([here](https://github.com/parcel-bundler/parcel/issues/2978)) but this change look ok.
