### PR TITLE
Add install_args setting to lektor-npm-support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,27 @@ This file instructs the plugin how to generate the assets:
 npm = yarn
 watch_script = watch
 build_script = build
+install_args = --force
 ```
 
 * The section name `[parcel]` is the name of the folder where the Parcel project is located.
 * `npm` is the package manager command used to build the project. This example will use [Yarn](https://yarnpkg.com).
 * `watch_script` is the npm script used in `lektor server -f npm`,
-* `build_script` is the npm script used in `lektor build -f npm`.
+* `build_script` is the npm script used in `lektor build -f npm`,
 
 This plugin supports more than one such entry.
+
+#### install_args
+
+```
+[parcel]
+npm = yarn
+install_args = --force
+watch_script = watch
+build_script = build
+```
+
+The `install_args` line is the argument string passed to `npm install`. This is optional, and only recommended if your project *needs* to use an install flag.
 
 ### `parcel/package.json`
 

--- a/lektor_npm_support.py
+++ b/lektor_npm_support.py
@@ -83,17 +83,21 @@ class ProcessManager(object):
 
 class NPMRunner(object):
 
-    def __init__(self, folder, npm, build_script, watch_script):
+    def __init__(self, folder, npm, build_script, watch_script, install_args):
         self.folder = folder
         self.npm = npm
         self.build_script = build_script
         self.watch_script = watch_script
+        self.install_args = install_args
 
     def npm_args(self, *args):
         return popen_args_type([self.npm] + list(args), self.folder)
 
     def build(self, proc):
-        proc.start(self.npm_args('install'), self.npm_args('run', self.build_script))
+        proc.start(
+            self.npm_args('install', self.install_args),
+            self.npm_args('run', self.build_script)
+        )
 
     def watch(self, proc):
         proc.start(self.npm_args('install'), self.npm_args('run', self.watch_script))
@@ -118,7 +122,8 @@ class NPMSupportPlugin(Plugin):
                 folder=os.path.join(self.env.root_path, section),
                 npm=props.get('npm', 'npm'),
                 build_script=props.get('build_script', 'build'),
-                watch_script=props.get('watch_script', 'watch')
+                watch_script=props.get('watch_script', 'watch'),
+                install_args=props.get('install_args', '')
             )
 
     def on_server_spawn(self, extra_flags, **extra):


### PR DESCRIPTION
Due to peer dependency conflicts, some projects require npm install to be run with --force, or the build fails. By adding this install_args setting, `npm install` flags can be added on a per-project basis.